### PR TITLE
 Removed the webMessaging properties, and we now transform some JSON arrays into comma-separated strings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ hs_err_pid*
 
 # Apple 
 .DS_Store
+/.gradle/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: java
 sudo: false
 script: mvn clean package
+jdk: 
+  - oraclejdk8

--- a/README.md
+++ b/README.md
@@ -61,19 +61,6 @@ session.connect();
 
 TODO: Add details.
 
-## A Note about Transforming VCAP_SERVICES
-
-The VCAP_SERVICES environment variable contains JSON arrays for many of the hostname properties.
-This is because when used in a High Availability environment, applications are provided with 
-two hostnames or IP addresses - one for the primary router and one for the backup.
-
-The JCSMP Java client library automatically takes care of switching to the backup router if the primary router becomes unavailable. It expects the HOST property to be a comma-separated list of hostnames.
-
-This cloud connector takes care of this by transforming the VCAP_SERVICES property 'smfHosts', which is a JSON array, into a property in the SolaceMessagingInfo class called 'smfHost', which is a string containing the comma-separated list of hostnames.
-
-This connector performs the same transformation on the properties smfTlsHosts, smfZipHosts, jmsJndiUris and jmsJndiTlsUris.
-
-
 ## Using it in your Application
 
 The releases from this project are hosted in [Maven Central](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.solace.labs.cloud.cloudfoundry%22%20AND%20a%3A%22solace-labs-spring-cloud-connector%22)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ SolaceMessagingInfo solacemessaging = (SolaceMessagingInfo) cloud.getServiceInfo
 
 // Setting up the JCSMP Connection
 final JCSMPProperties props = new JCSMPProperties();
-props.setProperty(JCSMPProperties.HOST, String.join(",", solacemessaging.getSmfHosts()));
+props.setProperty(JCSMPProperties.HOST, solacemessaging.getSmfHost());
 props.setProperty(JCSMPProperties.VPN_NAME, solacemessaging.getMsgVpnName());
 props.setProperty(JCSMPProperties.USERNAME, solacemessaging.getClientUsername());
 props.setProperty(JCSMPProperties.PASSWORD, solacemessaging.getClientPassword());
@@ -61,10 +61,22 @@ session.connect();
 
 TODO: Add details.
 
+## A Note about Transforming VCAP_SERVICES
+
+The VCAP_SERVICES environment variable contains JSON arrays for many of the hostname properties.
+This is because when used in a High Availability environment, applications are provided with 
+two hostnames or IP addresses - one for the primary router and one for the backup.
+
+The JCSMP Java client library automatically takes care of switching to the backup router if the primary router becomes unavailable. It expects the HOST property to be a comma-separated list of hostnames.
+
+This cloud connector takes care of this by transforming the VCAP_SERVICES property 'smfHosts', which is a JSON array, into a property in the SolaceMessagingInfo class called 'smfHost', which is a string containing the comma-separated list of hostnames.
+
+This connector performs the same transformation on the properties smfTlsHosts, smfZipHosts, jmsJndiUris and jmsJndiTlsUris.
+
 
 ## Using it in your Application
 
-This releases from this project are hosted in [Maven Central](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.solace.labs.cloud.cloudfoundry%22%20AND%20a%3A%22solace-labs-spring-cloud-connector%22)
+The releases from this project are hosted in [Maven Central](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.solace.labs.cloud.cloudfoundry%22%20AND%20a%3A%22solace-labs-spring-cloud-connector%22)
 
 ##Here is how to include it in your project using Gradle and Maven.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ SolaceMessagingInfo solacemessaging = (SolaceMessagingInfo) cloud.getServiceInfo
 
 // Setting up the JCSMP Connection
 final JCSMPProperties props = new JCSMPProperties();
-props.setProperty(JCSMPProperties.HOST, solacemessaging.getSmfHost());
+props.setProperty(JCSMPProperties.HOST, solacemessaging.getSmfHosts()[0]);
 props.setProperty(JCSMPProperties.VPN_NAME, solacemessaging.getMsgVpnName());
 props.setProperty(JCSMPProperties.USERNAME, solacemessaging.getClientUsername());
 props.setProperty(JCSMPProperties.PASSWORD, solacemessaging.getClientPassword());

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ SolaceMessagingInfo solacemessaging = (SolaceMessagingInfo) cloud.getServiceInfo
 
 // Setting up the JCSMP Connection
 final JCSMPProperties props = new JCSMPProperties();
-props.setProperty(JCSMPProperties.HOST, solacemessaging.getSmfHosts()[0]);
+props.setProperty(JCSMPProperties.HOST, String.join(",", solacemessaging.getSmfHosts()));
 props.setProperty(JCSMPProperties.VPN_NAME, solacemessaging.getMsgVpnName());
 props.setProperty(JCSMPProperties.USERNAME, solacemessaging.getClientUsername());
 props.setProperty(JCSMPProperties.PASSWORD, solacemessaging.getClientPassword());

--- a/pom.xml
+++ b/pom.xml
@@ -103,8 +103,8 @@
 				<version>3.5.1</version>
 				<configuration>
 					<!-- or whatever version you use -->
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingInfoCreator.java
+++ b/src/main/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingInfoCreator.java
@@ -47,8 +47,6 @@ public class SolaceMessagingInfoCreator extends CloudFoundryServiceInfoCreator<S
 		List<String> smfHosts = null;
 		List<String> smfTlsHosts = null;
 		List<String> smfZipHosts = null;
-		List<String> webMessagingUris = null;
-		List<String> webMessagingTlsUris = null;
 		List<String> jmsJndiUris = null;
 		List<String> jmsJndiTlsUris = null;
 		List<String> restUris = null;
@@ -93,12 +91,6 @@ public class SolaceMessagingInfoCreator extends CloudFoundryServiceInfoCreator<S
 			case "smfZipHosts":
 				smfZipHosts = (List<String>) value;
 				break;
-			case "webMessagingUris":
-				webMessagingUris = (List<String>) value;
-				break;
-			case "webMessagingTlsUris":
-				webMessagingTlsUris = (List<String>) value;
-				break;
 			case "jmsJndiUris":
 				jmsJndiUris = (List<String>) value;
 				break;
@@ -136,7 +128,7 @@ public class SolaceMessagingInfoCreator extends CloudFoundryServiceInfoCreator<S
 		}
 
 		SolaceMessagingInfo solMessagingInfo = new SolaceMessagingInfo(id, clientUsername, clientPassword, msgVpnName,
-				smfHosts, smfTlsHosts, smfZipHosts, webMessagingUris, webMessagingTlsUris, jmsJndiUris, jmsJndiTlsUris, restUris, restTlsUris, mqttUris,
+				smfHosts, smfTlsHosts, smfZipHosts, jmsJndiUris, jmsJndiTlsUris, restUris, restTlsUris, mqttUris,
 				mqttTlsUris, mqttWsUris, mqttWssUris, managementHostnames, managementPassword, managementUsername);
 
 		return solMessagingInfo;

--- a/src/main/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingInfoCreator.java
+++ b/src/main/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingInfoCreator.java
@@ -30,6 +30,12 @@ public class SolaceMessagingInfoCreator extends CloudFoundryServiceInfoCreator<S
 
 	// This creator will accept and parse any credentials that have the matching tag or label. 
 	// Therefore the default accept method is sufficient and doesn't need further specification.
+	
+	
+	// Some URI properties are represented in VCAP_SERVICES as JSON arrays, but 
+	// the JCSMP Java client library expects them as comma-separated strings.
+	// Therefore we do that transformation.
+
 	static private String solaceMessagingTag = "solace-messaging";
 
 	public SolaceMessagingInfoCreator() {
@@ -126,9 +132,24 @@ public class SolaceMessagingInfoCreator extends CloudFoundryServiceInfoCreator<S
 				break;
 			}
 		}
+		
+		
+		// Convert Lists to comma-separated strings on these properties, to be compatible with  the JCSMP Java client library.
+		String smfHost = null;
+		String smfTlsHost = null;
+		String smfZipHost = null;
+		String jmsJndiUri = null;
+		String jmsJndiTlsUri = null;
+				
+
+		if (smfHosts != null)       smfHost =       String.join(",", smfHosts);
+		if (smfTlsHosts != null)    smfTlsHost =    String.join(",", smfTlsHosts);
+		if (smfZipHosts != null)    smfZipHost =    String.join(",", smfZipHosts);
+		if (jmsJndiUris != null)    jmsJndiUri =    String.join(",", jmsJndiUris);
+		if (jmsJndiTlsUris != null) jmsJndiTlsUri = String.join(",", jmsJndiTlsUris);
 
 		SolaceMessagingInfo solMessagingInfo = new SolaceMessagingInfo(id, clientUsername, clientPassword, msgVpnName,
-				smfHosts, smfTlsHosts, smfZipHosts, jmsJndiUris, jmsJndiTlsUris, restUris, restTlsUris, mqttUris,
+				smfHost, smfTlsHost, smfZipHost, jmsJndiUri, jmsJndiTlsUri, restUris, restTlsUris, mqttUris,
 				mqttTlsUris, mqttWsUris, mqttWssUris, managementHostnames, managementPassword, managementUsername);
 
 		return solMessagingInfo;

--- a/src/main/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingInfoCreator.java
+++ b/src/main/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingInfoCreator.java
@@ -44,13 +44,13 @@ public class SolaceMessagingInfoCreator extends CloudFoundryServiceInfoCreator<S
 		String clientUsername = null;
 		String clientPassword = null;
 		String msgVpnName = null;
-		String smfHost = null;
-		String smfTlsHost = null;
-		String smfZipHost = null;
+		List<String> smfHosts = null;
+		List<String> smfTlsHosts = null;
+		List<String> smfZipHosts = null;
 		List<String> webMessagingUris = null;
 		List<String> webMessagingTlsUris = null;
-		String jmsJndiUri = null;
-		String jmsJndiTlsUri = null;
+		List<String> jmsJndiUris = null;
+		List<String> jmsJndiTlsUris = null;
 		List<String> restUris = null;
 		List<String> restTlsUris = null;
 		List<String> mqttUris = null;
@@ -84,14 +84,14 @@ public class SolaceMessagingInfoCreator extends CloudFoundryServiceInfoCreator<S
 			case "msgVpnName":
 				msgVpnName = (String) value;
 				break;
-			case "smfHost":
-				smfHost = (String) value;
+			case "smfHosts":
+				smfHosts = (List<String>) value;
 				break;
-			case "smfTlsHost":
-				smfTlsHost = (String) value;
+			case "smfTlsHosts":
+				smfTlsHosts = (List<String>) value;
 				break;
-			case "smfZipHost":
-				smfZipHost = (String) value;
+			case "smfZipHosts":
+				smfZipHosts = (List<String>) value;
 				break;
 			case "webMessagingUris":
 				webMessagingUris = (List<String>) value;
@@ -99,11 +99,11 @@ public class SolaceMessagingInfoCreator extends CloudFoundryServiceInfoCreator<S
 			case "webMessagingTlsUris":
 				webMessagingTlsUris = (List<String>) value;
 				break;
-			case "jmsJndiUri":
-				jmsJndiUri = (String) value;
+			case "jmsJndiUris":
+				jmsJndiUris = (List<String>) value;
 				break;
-			case "jmsJndiTlsUri":
-				jmsJndiTlsUri = (String) value;
+			case "jmsJndiTlsUris":
+				jmsJndiTlsUris = (List<String>) value;
 				break;
 			case "managementUsername":
 				managementUsername = (String) value;
@@ -136,7 +136,7 @@ public class SolaceMessagingInfoCreator extends CloudFoundryServiceInfoCreator<S
 		}
 
 		SolaceMessagingInfo solMessagingInfo = new SolaceMessagingInfo(id, clientUsername, clientPassword, msgVpnName,
-				smfHost, smfTlsHost, smfZipHost, webMessagingUris, webMessagingTlsUris, jmsJndiUri, jmsJndiTlsUri, restUris, restTlsUris, mqttUris,
+				smfHosts, smfTlsHosts, smfZipHosts, webMessagingUris, webMessagingTlsUris, jmsJndiUris, jmsJndiTlsUris, restUris, restTlsUris, mqttUris,
 				mqttTlsUris, mqttWsUris, mqttWssUris, managementHostnames, managementPassword, managementUsername);
 
 		return solMessagingInfo;

--- a/src/main/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingInfoCreator.java
+++ b/src/main/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingInfoCreator.java
@@ -47,8 +47,8 @@ public class SolaceMessagingInfoCreator extends CloudFoundryServiceInfoCreator<S
 		String smfHost = null;
 		String smfTlsHost = null;
 		String smfZipHost = null;
-		String webMessagingUri = null;
-		String webMessagingTlsUri = null;
+		List<String> webMessagingUris = null;
+		List<String> webMessagingTlsUris = null;
 		String jmsJndiUri = null;
 		String jmsJndiTlsUri = null;
 		List<String> restUris = null;
@@ -93,11 +93,11 @@ public class SolaceMessagingInfoCreator extends CloudFoundryServiceInfoCreator<S
 			case "smfZipHost":
 				smfZipHost = (String) value;
 				break;
-			case "webMessagingUri":
-				webMessagingUri = (String) value;
+			case "webMessagingUris":
+				webMessagingUris = (List<String>) value;
 				break;
-			case "webMessagingTlsUri":
-				webMessagingTlsUri = (String) value;
+			case "webMessagingTlsUris":
+				webMessagingTlsUris = (List<String>) value;
 				break;
 			case "jmsJndiUri":
 				jmsJndiUri = (String) value;
@@ -136,7 +136,7 @@ public class SolaceMessagingInfoCreator extends CloudFoundryServiceInfoCreator<S
 		}
 
 		SolaceMessagingInfo solMessagingInfo = new SolaceMessagingInfo(id, clientUsername, clientPassword, msgVpnName,
-				smfHost, smfTlsHost, smfZipHost, webMessagingUri, webMessagingTlsUri, jmsJndiUri, jmsJndiTlsUri, restUris, restTlsUris, mqttUris,
+				smfHost, smfTlsHost, smfZipHost, webMessagingUris, webMessagingTlsUris, jmsJndiUri, jmsJndiTlsUri, restUris, restTlsUris, mqttUris,
 				mqttTlsUris, mqttWsUris, mqttWssUris, managementHostnames, managementPassword, managementUsername);
 
 		return solMessagingInfo;

--- a/src/main/java/com/solace/labs/spring/cloud/core/SolaceMessagingInfo.java
+++ b/src/main/java/com/solace/labs/spring/cloud/core/SolaceMessagingInfo.java
@@ -39,11 +39,6 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	private String clientUsername;
 	private String clientPassword;
 	private String msgVpnName;
-	private List<String> smfHosts;
-	private List<String> smfTlsHosts;
-	private List<String> smfZipHosts;
-	private List<String> jmsJndiUris;
-	private List<String> jmsJndiTlsUris;
 	private List<String> restUris;
 	private List<String> restTlsUris;
 	private List<String> mqttUris;
@@ -53,8 +48,15 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	private List<String> managementHostnames;
 	private String managementPassword;
 	private String managementUsername;
-	private List<String> webMessagingUris;
-	private List<String> webMessagingTlsUris;
+	
+	// These properties are converted from arrays to comma separated strings
+	// for the convenience of the Solace APIs that expect them in that form.
+	
+	private String smfHost;
+	private String smfTlsHost;
+	private String smfZipHost;
+	private String jmsJndiUri;
+	private String jmsJndiTlsUri;
 
 	// Default constructor to enable bean unit testing.
 	public SolaceMessagingInfo() {
@@ -63,7 +65,6 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	
 	public SolaceMessagingInfo(String id, String clientUsername, String clientPassword, String msgVpnName,
 			List<String> smfHosts, List<String> smfTlsHosts, List<String> smfZipHosts,
-			List<String> webMessagingUris, List<String> webMessagingTlsUris,
 			List<String> jmsJndiUris, List<String> jmsJndiTlsUris,
 			List<String> restUris, List<String> restTlsUris, 
 			List<String> mqttUris, List<String> mqttTlsUris, List<String> mqttWsUris, List<String> mqttWssUris, 
@@ -72,13 +73,6 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 		this.clientUsername = clientUsername;
 		this.clientPassword = clientPassword;
 		this.msgVpnName = msgVpnName;
-		this.smfHosts = smfHosts;
-		this.smfTlsHosts = smfTlsHosts;
-		this.smfZipHosts = smfZipHosts;
-		this.webMessagingUris = webMessagingUris;
-		this.webMessagingTlsUris = webMessagingTlsUris;
-		this.jmsJndiUris = jmsJndiUris;
-		this.jmsJndiTlsUris = jmsJndiTlsUris;
 		this.restUris = restUris;
 		this.restTlsUris = restTlsUris;
 		this.mqttUris = mqttUris;
@@ -88,6 +82,12 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 		this.managementHostnames = managementHostnames;
 		this.managementPassword = managementPassword;
 		this.managementUsername = managementUsername;
+		
+		if (smfHosts != null)       smfHost =       String.join(",", smfHosts);
+		if (smfTlsHosts != null)    smfTlsHost =    String.join(",", smfTlsHosts);
+		if (smfZipHosts != null)    smfZipHost =    String.join(",", smfZipHosts);
+		if (jmsJndiUris != null)    jmsJndiUri =    String.join(",", jmsJndiUris);
+		if (jmsJndiTlsUris != null) jmsJndiTlsUri = String.join(",", jmsJndiTlsUris);
 	}
 
 	
@@ -117,59 +117,43 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	}
 
 	/**
-	 * @return the smfHosts
+	 * @return the smfHost
 	 */
 	@ServiceProperty
-	public List<String> getSmfHosts() {
-		return smfHosts;
+	public String getSmfHost() {
+		return smfHost;
 	}
 
 	/**
-	 * @return the smfTlsHosts
+	 * @return the smfTlsHost
 	 */
 	@ServiceProperty
-	public List<String> getSmfTlsHosts() {
-		return smfTlsHosts;
+	public String getSmfTlsHost() {
+		return smfTlsHost;
 	}
 
 	/**
-	 * @return the smfZipHosts
+	 * @return the smfZipHost
 	 */
 	@ServiceProperty
-	public List<String> getSmfZipHosts() {
-		return smfZipHosts;
+	public String getSmfZipHost() {
+		return smfZipHost;
 	}
 
 	/**
-	 * @return the webMessagingUri
+	 * @return the jmsJndiUri
 	 */
 	@ServiceProperty
-	public List<String> getWebMessagingUris() {
-		return webMessagingUris;
-	}
-	
-	/**
-	 * @return the webMessagingTlsUri
-	 */
-	@ServiceProperty
-	public List<String> getWebMessagingTlsUris() {
-		return webMessagingTlsUris;
+	public String getJmsJndiUri() {
+		return jmsJndiUri;
 	}
 
 	/**
-	 * @return the jmsJndiUris
+	 * @return the jmsJndiTlsUri
 	 */
 	@ServiceProperty
-	public List<String> getJmsJndiUris() {
-		return jmsJndiUris;
-	}
-
-	/**
-	 * @return the jmsJndiTlsUris
-	 */
-	@ServiceProperty
-	public List<String> getJmsJndiTlsUris() {
-		return jmsJndiTlsUris;
+	public String getJmsJndiTlsUri() {
+		return jmsJndiTlsUri;
 	}
 
 	/**
@@ -220,6 +204,7 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 		return mqttWssUris;
 	}
 
+
 	/**
 	 * @return the managementHostnames
 	 */
@@ -266,8 +251,8 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 		result = prime * result + ((id == null) ? 0 : id.hashCode());
 		result = prime * result + ((clientPassword == null) ? 0 : clientPassword.hashCode());
 		result = prime * result + ((clientUsername == null) ? 0 : clientUsername.hashCode());
-		result = prime * result + ((jmsJndiTlsUris == null) ? 0 : jmsJndiTlsUris.hashCode());
-		result = prime * result + ((jmsJndiUris == null) ? 0 : jmsJndiUris.hashCode());
+		result = prime * result + ((jmsJndiTlsUri == null) ? 0 : jmsJndiTlsUri.hashCode());
+		result = prime * result + ((jmsJndiUri == null) ? 0 : jmsJndiUri.hashCode());
 		result = prime * result + ((managementHostnames == null) ? 0 : managementHostnames.hashCode());
 		result = prime * result + ((managementPassword == null) ? 0 : managementPassword.hashCode());
 		result = prime * result + ((managementUsername == null) ? 0 : managementUsername.hashCode());
@@ -278,11 +263,9 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 		result = prime * result + ((msgVpnName == null) ? 0 : msgVpnName.hashCode());
 		result = prime * result + ((restTlsUris == null) ? 0 : restTlsUris.hashCode());
 		result = prime * result + ((restUris == null) ? 0 : restUris.hashCode());
-		result = prime * result + ((smfTlsHosts == null) ? 0 : smfTlsHosts.hashCode());
-		result = prime * result + ((smfHosts == null) ? 0 : smfHosts.hashCode());
-		result = prime * result + ((smfZipHosts == null) ? 0 : smfZipHosts.hashCode());
-		result = prime * result + ((webMessagingUris == null) ? 0 : webMessagingUris.hashCode());
-		result = prime * result + ((webMessagingTlsUris == null) ? 0 : webMessagingTlsUris.hashCode());
+		result = prime * result + ((smfTlsHost == null) ? 0 : smfTlsHost.hashCode());
+		result = prime * result + ((smfHost == null) ? 0 : smfHost.hashCode());
+		result = prime * result + ((smfZipHost == null) ? 0 : smfZipHost.hashCode());
 		return result;
 	}
 
@@ -315,15 +298,15 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 				return false;
 		} else if (!clientUsername.equals(other.clientUsername))
 			return false;
-		if (jmsJndiTlsUris == null) {
-			if (other.jmsJndiTlsUris != null)
+		if (jmsJndiTlsUri == null) {
+			if (other.jmsJndiTlsUri != null)
 				return false;
-		} else if (!jmsJndiTlsUris.equals(other.jmsJndiTlsUris))
+		} else if (!jmsJndiTlsUri.equals(other.jmsJndiTlsUri))
 			return false;
-		if (jmsJndiUris == null) {
-			if (other.jmsJndiUris != null)
+		if (jmsJndiUri == null) {
+			if (other.jmsJndiUri != null)
 				return false;
-		} else if (!jmsJndiUris.equals(other.jmsJndiUris))
+		} else if (!jmsJndiUri.equals(other.jmsJndiUri))
 			return false;
 		if (managementHostnames == null) {
 			if (other.managementHostnames != null)
@@ -375,30 +358,20 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 				return false;
 		} else if (!restUris.equals(other.restUris))
 			return false;
-		if (smfTlsHosts == null) {
-			if (other.smfTlsHosts != null)
+		if (smfTlsHost == null) {
+			if (other.smfTlsHost != null)
 				return false;
-		} else if (!smfTlsHosts.equals(other.smfTlsHosts))
+		} else if (!smfTlsHost.equals(other.smfTlsHost))
 			return false;
-		if (smfHosts == null) {
-			if (other.smfHosts != null)
+		if (smfHost == null) {
+			if (other.smfHost != null)
 				return false;
-		} else if (!smfHosts.equals(other.smfHosts))
+		} else if (!smfHost.equals(other.smfHost))
 			return false;
-		if (smfZipHosts == null) {
-			if (other.smfZipHosts != null)
+		if (smfZipHost == null) {
+			if (other.smfZipHost != null)
 				return false;
-		} else if (!smfZipHosts.equals(other.smfZipHosts))
-			return false;
-		if (webMessagingUris == null) {
-			if (other.webMessagingUris != null)
-				return false;
-		} else if (!webMessagingUris.equals(other.webMessagingUris))
-			return false;
-		if (webMessagingTlsUris == null) {
-			if (other.webMessagingTlsUris != null)
-				return false;
-		} else if (!webMessagingTlsUris.equals(other.webMessagingTlsUris))
+		} else if (!smfZipHost.equals(other.smfZipHost))
 			return false;
 		return true;
 	}

--- a/src/main/java/com/solace/labs/spring/cloud/core/SolaceMessagingInfo.java
+++ b/src/main/java/com/solace/labs/spring/cloud/core/SolaceMessagingInfo.java
@@ -42,7 +42,6 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	private String smfHost;
 	private String smfTlsHost;
 	private String smfZipHost;
-	private String webMessagingUri;
 	private String jmsJndiUri;
 	private String jmsJndiTlsUri;
 	private List<String> restUris;
@@ -54,7 +53,8 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	private List<String> managementHostnames;
 	private String managementPassword;
 	private String managementUsername;
-	private String webMessagingTlsUri;
+	private List<String> webMessagingUris;
+	private List<String> webMessagingTlsUris;
 
 	// Default constructor to enable bean unit testing.
 	public SolaceMessagingInfo() {
@@ -62,10 +62,12 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	}
 	
 	public SolaceMessagingInfo(String id, String clientUsername, String clientPassword, String msgVpnName,
-			String smfHost, String smfTlsHost, String smfZipHost, String webMessagingUri,String webMessagingTlsUri, String jmsJndiUri, String jmsJndiTlsUri,
-			List<String> restUris, List<String> restTlsUris, List<String> mqttUris, List<String> mqttTlsUris,
-			List<String> mqttWsUris, List<String> mqttWssUris, List<String> managementHostnames,
-			String managementPassword, String managementUsername) {
+			String smfHost, String smfTlsHost, String smfZipHost,
+			List<String> webMessagingUris, List<String> webMessagingTlsUris,
+			String jmsJndiUri, String jmsJndiTlsUri,
+			List<String> restUris, List<String> restTlsUris, 
+			List<String> mqttUris, List<String> mqttTlsUris, List<String> mqttWsUris, List<String> mqttWssUris, 
+			List<String> managementHostnames, String managementPassword, String managementUsername) {
 		super(id);
 		this.clientUsername = clientUsername;
 		this.clientPassword = clientPassword;
@@ -73,8 +75,8 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 		this.smfHost = smfHost;
 		this.smfTlsHost = smfTlsHost;
 		this.smfZipHost = smfZipHost;
-		this.webMessagingUri = webMessagingUri;
-		this.webMessagingTlsUri = webMessagingTlsUri;
+		this.webMessagingUris = webMessagingUris;
+		this.webMessagingTlsUris = webMessagingTlsUris;
 		this.jmsJndiUri = jmsJndiUri;
 		this.jmsJndiTlsUri = jmsJndiTlsUri;
 		this.restUris = restUris;
@@ -142,16 +144,16 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	 * @return the webMessagingUri
 	 */
 	@ServiceProperty
-	public String getWebMessagingUri() {
-		return webMessagingUri;
+	public List<String> getWebMessagingUris() {
+		return webMessagingUris;
 	}
 	
 	/**
 	 * @return the webMessagingTlsUri
 	 */
 	@ServiceProperty
-	public String getWebMessagingTlsUri() {
-		return webMessagingTlsUri;
+	public List<String> getWebMessagingTlsUris() {
+		return webMessagingTlsUris;
 	}
 
 	/**
@@ -279,8 +281,8 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 		result = prime * result + ((smfTlsHost == null) ? 0 : smfTlsHost.hashCode());
 		result = prime * result + ((smfHost == null) ? 0 : smfHost.hashCode());
 		result = prime * result + ((smfZipHost == null) ? 0 : smfZipHost.hashCode());
-		result = prime * result + ((webMessagingUri == null) ? 0 : webMessagingUri.hashCode());
-		result = prime * result + ((webMessagingTlsUri == null) ? 0 : webMessagingTlsUri.hashCode());
+		result = prime * result + ((webMessagingUris == null) ? 0 : webMessagingUris.hashCode());
+		result = prime * result + ((webMessagingTlsUris == null) ? 0 : webMessagingTlsUris.hashCode());
 		return result;
 	}
 
@@ -388,15 +390,15 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 				return false;
 		} else if (!smfZipHost.equals(other.smfZipHost))
 			return false;
-		if (webMessagingUri == null) {
-			if (other.webMessagingUri != null)
+		if (webMessagingUris == null) {
+			if (other.webMessagingUris != null)
 				return false;
-		} else if (!webMessagingUri.equals(other.webMessagingUri))
+		} else if (!webMessagingUris.equals(other.webMessagingUris))
 			return false;
-		if (webMessagingTlsUri == null) {
-			if (other.webMessagingTlsUri != null)
+		if (webMessagingTlsUris == null) {
+			if (other.webMessagingTlsUris != null)
 				return false;
-		} else if (!webMessagingTlsUri.equals(other.webMessagingTlsUri))
+		} else if (!webMessagingTlsUris.equals(other.webMessagingTlsUris))
 			return false;
 		return true;
 	}

--- a/src/main/java/com/solace/labs/spring/cloud/core/SolaceMessagingInfo.java
+++ b/src/main/java/com/solace/labs/spring/cloud/core/SolaceMessagingInfo.java
@@ -39,11 +39,11 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	private String clientUsername;
 	private String clientPassword;
 	private String msgVpnName;
-	private String smfHost;
-	private String smfTlsHost;
-	private String smfZipHost;
-	private String jmsJndiUri;
-	private String jmsJndiTlsUri;
+	private List<String> smfHosts;
+	private List<String> smfTlsHosts;
+	private List<String> smfZipHosts;
+	private List<String> jmsJndiUris;
+	private List<String> jmsJndiTlsUris;
 	private List<String> restUris;
 	private List<String> restTlsUris;
 	private List<String> mqttUris;
@@ -62,9 +62,9 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	}
 	
 	public SolaceMessagingInfo(String id, String clientUsername, String clientPassword, String msgVpnName,
-			String smfHost, String smfTlsHost, String smfZipHost,
+			List<String> smfHosts, List<String> smfTlsHosts, List<String> smfZipHosts,
 			List<String> webMessagingUris, List<String> webMessagingTlsUris,
-			String jmsJndiUri, String jmsJndiTlsUri,
+			List<String> jmsJndiUris, List<String> jmsJndiTlsUris,
 			List<String> restUris, List<String> restTlsUris, 
 			List<String> mqttUris, List<String> mqttTlsUris, List<String> mqttWsUris, List<String> mqttWssUris, 
 			List<String> managementHostnames, String managementPassword, String managementUsername) {
@@ -72,13 +72,13 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 		this.clientUsername = clientUsername;
 		this.clientPassword = clientPassword;
 		this.msgVpnName = msgVpnName;
-		this.smfHost = smfHost;
-		this.smfTlsHost = smfTlsHost;
-		this.smfZipHost = smfZipHost;
+		this.smfHosts = smfHosts;
+		this.smfTlsHosts = smfTlsHosts;
+		this.smfZipHosts = smfZipHosts;
 		this.webMessagingUris = webMessagingUris;
 		this.webMessagingTlsUris = webMessagingTlsUris;
-		this.jmsJndiUri = jmsJndiUri;
-		this.jmsJndiTlsUri = jmsJndiTlsUri;
+		this.jmsJndiUris = jmsJndiUris;
+		this.jmsJndiTlsUris = jmsJndiTlsUris;
 		this.restUris = restUris;
 		this.restTlsUris = restTlsUris;
 		this.mqttUris = mqttUris;
@@ -117,27 +117,27 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	}
 
 	/**
-	 * @return the smfHost
+	 * @return the smfHosts
 	 */
 	@ServiceProperty
-	public String getSmfHost() {
-		return smfHost;
+	public List<String> getSmfHosts() {
+		return smfHosts;
 	}
 
 	/**
-	 * @return the smfTlsHost
+	 * @return the smfTlsHosts
 	 */
 	@ServiceProperty
-	public String getSmfTlsHost() {
-		return smfTlsHost;
+	public List<String> getSmfTlsHosts() {
+		return smfTlsHosts;
 	}
 
 	/**
-	 * @return the smfZipHost
+	 * @return the smfZipHosts
 	 */
 	@ServiceProperty
-	public String getSmfZipHost() {
-		return smfZipHost;
+	public List<String> getSmfZipHosts() {
+		return smfZipHosts;
 	}
 
 	/**
@@ -157,19 +157,19 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	}
 
 	/**
-	 * @return the jmsJndiUri
+	 * @return the jmsJndiUris
 	 */
 	@ServiceProperty
-	public String getJmsJndiUri() {
-		return jmsJndiUri;
+	public List<String> getJmsJndiUris() {
+		return jmsJndiUris;
 	}
 
 	/**
-	 * @return the jmsJndiTlsUri
+	 * @return the jmsJndiTlsUris
 	 */
 	@ServiceProperty
-	public String getJmsJndiTlsUri() {
-		return jmsJndiTlsUri;
+	public List<String> getJmsJndiTlsUris() {
+		return jmsJndiTlsUris;
 	}
 
 	/**
@@ -266,8 +266,8 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 		result = prime * result + ((id == null) ? 0 : id.hashCode());
 		result = prime * result + ((clientPassword == null) ? 0 : clientPassword.hashCode());
 		result = prime * result + ((clientUsername == null) ? 0 : clientUsername.hashCode());
-		result = prime * result + ((jmsJndiTlsUri == null) ? 0 : jmsJndiTlsUri.hashCode());
-		result = prime * result + ((jmsJndiUri == null) ? 0 : jmsJndiUri.hashCode());
+		result = prime * result + ((jmsJndiTlsUris == null) ? 0 : jmsJndiTlsUris.hashCode());
+		result = prime * result + ((jmsJndiUris == null) ? 0 : jmsJndiUris.hashCode());
 		result = prime * result + ((managementHostnames == null) ? 0 : managementHostnames.hashCode());
 		result = prime * result + ((managementPassword == null) ? 0 : managementPassword.hashCode());
 		result = prime * result + ((managementUsername == null) ? 0 : managementUsername.hashCode());
@@ -278,9 +278,9 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 		result = prime * result + ((msgVpnName == null) ? 0 : msgVpnName.hashCode());
 		result = prime * result + ((restTlsUris == null) ? 0 : restTlsUris.hashCode());
 		result = prime * result + ((restUris == null) ? 0 : restUris.hashCode());
-		result = prime * result + ((smfTlsHost == null) ? 0 : smfTlsHost.hashCode());
-		result = prime * result + ((smfHost == null) ? 0 : smfHost.hashCode());
-		result = prime * result + ((smfZipHost == null) ? 0 : smfZipHost.hashCode());
+		result = prime * result + ((smfTlsHosts == null) ? 0 : smfTlsHosts.hashCode());
+		result = prime * result + ((smfHosts == null) ? 0 : smfHosts.hashCode());
+		result = prime * result + ((smfZipHosts == null) ? 0 : smfZipHosts.hashCode());
 		result = prime * result + ((webMessagingUris == null) ? 0 : webMessagingUris.hashCode());
 		result = prime * result + ((webMessagingTlsUris == null) ? 0 : webMessagingTlsUris.hashCode());
 		return result;
@@ -315,15 +315,15 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 				return false;
 		} else if (!clientUsername.equals(other.clientUsername))
 			return false;
-		if (jmsJndiTlsUri == null) {
-			if (other.jmsJndiTlsUri != null)
+		if (jmsJndiTlsUris == null) {
+			if (other.jmsJndiTlsUris != null)
 				return false;
-		} else if (!jmsJndiTlsUri.equals(other.jmsJndiTlsUri))
+		} else if (!jmsJndiTlsUris.equals(other.jmsJndiTlsUris))
 			return false;
-		if (jmsJndiUri == null) {
-			if (other.jmsJndiUri != null)
+		if (jmsJndiUris == null) {
+			if (other.jmsJndiUris != null)
 				return false;
-		} else if (!jmsJndiUri.equals(other.jmsJndiUri))
+		} else if (!jmsJndiUris.equals(other.jmsJndiUris))
 			return false;
 		if (managementHostnames == null) {
 			if (other.managementHostnames != null)
@@ -375,20 +375,20 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 				return false;
 		} else if (!restUris.equals(other.restUris))
 			return false;
-		if (smfTlsHost == null) {
-			if (other.smfTlsHost != null)
+		if (smfTlsHosts == null) {
+			if (other.smfTlsHosts != null)
 				return false;
-		} else if (!smfTlsHost.equals(other.smfTlsHost))
+		} else if (!smfTlsHosts.equals(other.smfTlsHosts))
 			return false;
-		if (smfHost == null) {
-			if (other.smfHost != null)
+		if (smfHosts == null) {
+			if (other.smfHosts != null)
 				return false;
-		} else if (!smfHost.equals(other.smfHost))
+		} else if (!smfHosts.equals(other.smfHosts))
 			return false;
-		if (smfZipHost == null) {
-			if (other.smfZipHost != null)
+		if (smfZipHosts == null) {
+			if (other.smfZipHosts != null)
 				return false;
-		} else if (!smfZipHost.equals(other.smfZipHost))
+		} else if (!smfZipHosts.equals(other.smfZipHosts))
 			return false;
 		if (webMessagingUris == null) {
 			if (other.webMessagingUris != null)

--- a/src/main/java/com/solace/labs/spring/cloud/core/SolaceMessagingInfo.java
+++ b/src/main/java/com/solace/labs/spring/cloud/core/SolaceMessagingInfo.java
@@ -31,7 +31,7 @@ import org.springframework.cloud.service.ServiceInfo.ServiceLabel;
  * 
  * For more details see the GitHub project:
  *    - https://github.com/SolaceLabs/sl-solace-messaging-service-info
- * 
+ *    
  */
 @ServiceLabel("solacemessaging")
 public class SolaceMessagingInfo extends BaseServiceInfo {
@@ -39,6 +39,11 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	private String clientUsername;
 	private String clientPassword;
 	private String msgVpnName;
+	private String smfHost;
+	private String smfTlsHost;
+	private String smfZipHost;
+	private String jmsJndiUri;
+	private String jmsJndiTlsUri;
 	private List<String> restUris;
 	private List<String> restTlsUris;
 	private List<String> mqttUris;
@@ -49,14 +54,6 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	private String managementPassword;
 	private String managementUsername;
 	
-	// These properties are converted from arrays to comma separated strings
-	// for the convenience of the Solace APIs that expect them in that form.
-	
-	private String smfHost;
-	private String smfTlsHost;
-	private String smfZipHost;
-	private String jmsJndiUri;
-	private String jmsJndiTlsUri;
 
 	// Default constructor to enable bean unit testing.
 	public SolaceMessagingInfo() {
@@ -64,15 +61,19 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 	}
 	
 	public SolaceMessagingInfo(String id, String clientUsername, String clientPassword, String msgVpnName,
-			List<String> smfHosts, List<String> smfTlsHosts, List<String> smfZipHosts,
-			List<String> jmsJndiUris, List<String> jmsJndiTlsUris,
-			List<String> restUris, List<String> restTlsUris, 
-			List<String> mqttUris, List<String> mqttTlsUris, List<String> mqttWsUris, List<String> mqttWssUris, 
-			List<String> managementHostnames, String managementPassword, String managementUsername) {
+			String smfHost, String smfTlsHost, String smfZipHost, String jmsJndiUri, String jmsJndiTlsUri,
+			List<String> restUris, List<String> restTlsUris, List<String> mqttUris, List<String> mqttTlsUris,
+			List<String> mqttWsUris, List<String> mqttWssUris, List<String> managementHostnames,
+			String managementPassword, String managementUsername) {
 		super(id);
 		this.clientUsername = clientUsername;
 		this.clientPassword = clientPassword;
 		this.msgVpnName = msgVpnName;
+		this.smfHost = smfHost;
+		this.smfTlsHost = smfTlsHost;
+		this.smfZipHost = smfZipHost;
+		this.jmsJndiUri = jmsJndiUri;
+		this.jmsJndiTlsUri = jmsJndiTlsUri;
 		this.restUris = restUris;
 		this.restTlsUris = restTlsUris;
 		this.mqttUris = mqttUris;
@@ -82,12 +83,6 @@ public class SolaceMessagingInfo extends BaseServiceInfo {
 		this.managementHostnames = managementHostnames;
 		this.managementPassword = managementPassword;
 		this.managementUsername = managementUsername;
-		
-		if (smfHosts != null)       smfHost =       String.join(",", smfHosts);
-		if (smfTlsHosts != null)    smfTlsHost =    String.join(",", smfTlsHosts);
-		if (smfZipHosts != null)    smfZipHost =    String.join(",", smfZipHosts);
-		if (jmsJndiUris != null)    jmsJndiUri =    String.join(",", jmsJndiUris);
-		if (jmsJndiTlsUris != null) jmsJndiTlsUri = String.join(",", jmsJndiTlsUris);
 	}
 
 	

--- a/src/test/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingServiceInfoCreatorTest.java
+++ b/src/test/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingServiceInfoCreatorTest.java
@@ -92,7 +92,7 @@ public class SolaceMessagingServiceInfoCreatorTest {
 
 		@SuppressWarnings("unchecked")
 		Map<String, Object> exCred = (Map<String, Object>) exVcapServices.get("credentials");
-		exCred.remove("smfHost");
+		exCred.remove("smfHosts");
 		
 		SolaceMessagingInfoCreator smic = new SolaceMessagingInfoCreator();
 
@@ -102,9 +102,8 @@ public class SolaceMessagingServiceInfoCreatorTest {
 		SolaceMessagingInfo smi = smic.createServiceInfo(exVcapServices);
 		
 		// Validate smf is null. Others are not
-		assertNull(smi.getSmfHost());
-		assertEquals("tcps://192.168.1.50:7003", smi.getSmfTlsHost());
-		
+		assertNull(smi.getSmfHosts());
+		assertThat(smi.getSmfTlsHosts(), is(Arrays.asList("tcps://192.168.1.50:7003")));		
 	}
 	
 	@Test 
@@ -150,13 +149,13 @@ public class SolaceMessagingServiceInfoCreatorTest {
 		exCred.put("clientUsername", "sample-client-username");
 		exCred.put("clientPassword", "sample-client-password");
 		exCred.put("msgVpnName", "sample-msg-vpn");
-		exCred.put("smfHost", "tcp://192.168.1.50:7000");
-		exCred.put("smfTlsHost", "tcps://192.168.1.50:7003");
-		exCred.put("smfZipHost", "tcp://192.168.1.50:7001");
+		exCred.put("smfHosts", Arrays.asList("tcp://192.168.1.50:7000"));
+		exCred.put("smfTlsHosts", Arrays.asList("tcps://192.168.1.50:7003"));
+		exCred.put("smfZipHosts", Arrays.asList("tcp://192.168.1.50:7001"));
 		exCred.put("webMessagingUris", Arrays.asList("http://192.168.1.50:80"));
 		exCred.put("webMessagingTlsUris", Arrays.asList("https://192.168.1.50:80"));
-		exCred.put("jmsJndiUri", "smf://192.168.1.50:7000");
-		exCred.put("jmsJndiTlsUri", "smfs://192.168.1.50:7003");
+		exCred.put("jmsJndiUris", Arrays.asList("smf://192.168.1.50:7000"));
+		exCred.put("jmsJndiTlsUris", Arrays.asList("smfs://192.168.1.50:7003"));
 		exCred.put("mqttUris", Arrays.asList("tcp://192.168.1.50:7020"));
 		exCred.put("mqttTlsUris", Arrays.asList("ssl://192.168.1.50:7021"));
 		exCred.put("mqttWsUris", Arrays.asList("ws://192.168.1.50:7022"));
@@ -187,15 +186,19 @@ public class SolaceMessagingServiceInfoCreatorTest {
 		assertEquals("sample-msg-vpn", smi.getMsgVpnName());
 
 		// Check SMF
-		assertEquals("tcp://192.168.1.50:7000", smi.getSmfHost());
-		assertEquals("tcps://192.168.1.50:7003", smi.getSmfTlsHost());
-		assertEquals("tcp://192.168.1.50:7001", smi.getSmfZipHost());
+		assertThat(smi.getSmfHosts(), is(Arrays.asList("tcp://192.168.1.50:7000")));
+		assertThat(smi.getSmfTlsHosts(), is(Arrays.asList("tcps://192.168.1.50:7003")));
+		assertThat(smi.getSmfZipHosts(), is(Arrays.asList("tcp://192.168.1.50:7001")));
 
 		// Check Web Messaging
 		assertThat(smi.getWebMessagingUris(), is(Arrays.asList("http://192.168.1.50:80")));
 		assertThat(smi.getWebMessagingTlsUris(), is(Arrays.asList("https://192.168.1.50:80")));
 
 		// Check JMS
+		assertThat(smi.getJmsJndiUris(), is(Arrays.asList("smf://192.168.1.50:7000")));
+		assertThat(smi.getJmsJndiTlsUris(), is(Arrays.asList("smfs://192.168.1.50:7003")));
+		
+		// Check MQTT
 		assertThat(smi.getMqttUris(), is(Arrays.asList("tcp://192.168.1.50:7020")));
 		assertThat(smi.getMqttTlsUris(), is(Arrays.asList("ssl://192.168.1.50:7021")));
 		assertThat(smi.getMqttWsUris(), is(Arrays.asList("ws://192.168.1.50:7022")));

--- a/src/test/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingServiceInfoCreatorTest.java
+++ b/src/test/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingServiceInfoCreatorTest.java
@@ -153,8 +153,8 @@ public class SolaceMessagingServiceInfoCreatorTest {
 		exCred.put("smfHost", "tcp://192.168.1.50:7000");
 		exCred.put("smfTlsHost", "tcps://192.168.1.50:7003");
 		exCred.put("smfZipHost", "tcp://192.168.1.50:7001");
-		exCred.put("webMessagingUri", "http://192.168.1.50:80");
-		exCred.put("webMessagingTlsUri", "https://192.168.1.50:80");
+		exCred.put("webMessagingUris", Arrays.asList("http://192.168.1.50:80"));
+		exCred.put("webMessagingTlsUris", Arrays.asList("https://192.168.1.50:80"));
 		exCred.put("jmsJndiUri", "smf://192.168.1.50:7000");
 		exCred.put("jmsJndiTlsUri", "smfs://192.168.1.50:7003");
 		exCred.put("mqttUris", Arrays.asList("tcp://192.168.1.50:7020"));
@@ -191,8 +191,9 @@ public class SolaceMessagingServiceInfoCreatorTest {
 		assertEquals("tcps://192.168.1.50:7003", smi.getSmfTlsHost());
 		assertEquals("tcp://192.168.1.50:7001", smi.getSmfZipHost());
 
-		// Check Web Messsaging
-		assertEquals("http://192.168.1.50:80", smi.getWebMessagingUri());
+		// Check Web Messaging
+		assertThat(smi.getWebMessagingUris(), is(Arrays.asList("http://192.168.1.50:80")));
+		assertThat(smi.getWebMessagingTlsUris(), is(Arrays.asList("https://192.168.1.50:80")));
 
 		// Check JMS
 		assertThat(smi.getMqttUris(), is(Arrays.asList("tcp://192.168.1.50:7020")));

--- a/src/test/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingServiceInfoCreatorTest.java
+++ b/src/test/java/com/solace/labs/spring/cloud/cloudfoundry/SolaceMessagingServiceInfoCreatorTest.java
@@ -102,8 +102,8 @@ public class SolaceMessagingServiceInfoCreatorTest {
 		SolaceMessagingInfo smi = smic.createServiceInfo(exVcapServices);
 		
 		// Validate smf is null. Others are not
-		assertNull(smi.getSmfHosts());
-		assertThat(smi.getSmfTlsHosts(), is(Arrays.asList("tcps://192.168.1.50:7003")));		
+		assertNull(smi.getSmfHost());
+		assertEquals("tcps://192.168.1.50:7003,tcps://192.168.1.51:7003", smi.getSmfTlsHost());
 	}
 	
 	@Test 
@@ -150,16 +150,16 @@ public class SolaceMessagingServiceInfoCreatorTest {
 		exCred.put("clientPassword", "sample-client-password");
 		exCred.put("msgVpnName", "sample-msg-vpn");
 		exCred.put("smfHosts", Arrays.asList("tcp://192.168.1.50:7000"));
-		exCred.put("smfTlsHosts", Arrays.asList("tcps://192.168.1.50:7003"));
+		exCred.put("smfTlsHosts", Arrays.asList("tcps://192.168.1.50:7003", "tcps://192.168.1.51:7003"));
 		exCred.put("smfZipHosts", Arrays.asList("tcp://192.168.1.50:7001"));
 		exCred.put("webMessagingUris", Arrays.asList("http://192.168.1.50:80"));
 		exCred.put("webMessagingTlsUris", Arrays.asList("https://192.168.1.50:80"));
 		exCred.put("jmsJndiUris", Arrays.asList("smf://192.168.1.50:7000"));
-		exCred.put("jmsJndiTlsUris", Arrays.asList("smfs://192.168.1.50:7003"));
+		exCred.put("jmsJndiTlsUris", Arrays.asList("smfs://192.168.1.50:7003", "smfs://192.168.1.51:7003"));
 		exCred.put("mqttUris", Arrays.asList("tcp://192.168.1.50:7020"));
-		exCred.put("mqttTlsUris", Arrays.asList("ssl://192.168.1.50:7021"));
+		exCred.put("mqttTlsUris", Arrays.asList("ssl://192.168.1.50:7021", "ssl://192.168.1.51:7021"));
 		exCred.put("mqttWsUris", Arrays.asList("ws://192.168.1.50:7022"));
-		exCred.put("mqttWssUris", Arrays.asList("wss://192.168.1.50:7023"));
+		exCred.put("mqttWssUris", Arrays.asList("wss://192.168.1.50:7023", "wss://192.168.1.51:7023"));
 		exCred.put("restUris", Arrays.asList("http://192.168.1.50:7018"));
 		exCred.put("restTlsUris", Arrays.asList("https://192.168.1.50:7019"));
 		exCred.put("managementHostnames", Arrays.asList("vmr-Medium-VMR-0"));
@@ -186,23 +186,19 @@ public class SolaceMessagingServiceInfoCreatorTest {
 		assertEquals("sample-msg-vpn", smi.getMsgVpnName());
 
 		// Check SMF
-		assertThat(smi.getSmfHosts(), is(Arrays.asList("tcp://192.168.1.50:7000")));
-		assertThat(smi.getSmfTlsHosts(), is(Arrays.asList("tcps://192.168.1.50:7003")));
-		assertThat(smi.getSmfZipHosts(), is(Arrays.asList("tcp://192.168.1.50:7001")));
-
-		// Check Web Messaging
-		assertThat(smi.getWebMessagingUris(), is(Arrays.asList("http://192.168.1.50:80")));
-		assertThat(smi.getWebMessagingTlsUris(), is(Arrays.asList("https://192.168.1.50:80")));
+		assertEquals("tcp://192.168.1.50:7000", smi.getSmfHost());
+		assertEquals("tcps://192.168.1.50:7003,tcps://192.168.1.51:7003", smi.getSmfTlsHost());
+		assertEquals("tcp://192.168.1.50:7001", smi.getSmfZipHost());
 
 		// Check JMS
-		assertThat(smi.getJmsJndiUris(), is(Arrays.asList("smf://192.168.1.50:7000")));
-		assertThat(smi.getJmsJndiTlsUris(), is(Arrays.asList("smfs://192.168.1.50:7003")));
-		
+		assertEquals("smf://192.168.1.50:7000", smi.getJmsJndiUri());
+		assertEquals("smfs://192.168.1.50:7003,smfs://192.168.1.51:7003", smi.getJmsJndiTlsUri());
+
 		// Check MQTT
 		assertThat(smi.getMqttUris(), is(Arrays.asList("tcp://192.168.1.50:7020")));
-		assertThat(smi.getMqttTlsUris(), is(Arrays.asList("ssl://192.168.1.50:7021")));
+		assertThat(smi.getMqttTlsUris(), is(Arrays.asList("ssl://192.168.1.50:7021", "ssl://192.168.1.51:7021")));
 		assertThat(smi.getMqttWsUris(), is(Arrays.asList("ws://192.168.1.50:7022")));
-		assertThat(smi.getMqttWssUris(), is(Arrays.asList("wss://192.168.1.50:7023")));
+		assertThat(smi.getMqttWssUris(), is(Arrays.asList("wss://192.168.1.50:7023", "wss://192.168.1.51:7023")));
 
 		// Check REST
 		assertThat(smi.getRestUris(), is(Arrays.asList("http://192.168.1.50:7018")));

--- a/src/test/java/com/solace/labs/spring/cloud/core/SolaceMessagingServiceInfoTest.java
+++ b/src/test/java/com/solace/labs/spring/cloud/core/SolaceMessagingServiceInfoTest.java
@@ -43,8 +43,8 @@ public class SolaceMessagingServiceInfoTest {
 		String smfHost = "tcp://192.168.1.50:7000";
 		String smfTlsHost = "tcps://192.168.1.50:7003";
 		String smfZipHost = "tcp://192.168.1.50:7001";
-		String webMessagingUri = "http://192.168.1.50:80";
-		String webMessagingTlsUri = "https://192.168.1.50:80";
+		List<String> webMessagingUris = Arrays.asList("http://192.168.1.50:80");
+		List<String> webMessagingTlsUris = Arrays.asList("https://192.168.1.50:80");
 		String jmsJndiUri = "smf://192.168.1.50:7000";
 		String jmsJndiTlsUri = "smfs://192.168.1.50:7003";
 		List<String> mqttUris = Arrays.asList("tcp://192.168.1.50:7020");
@@ -58,7 +58,7 @@ public class SolaceMessagingServiceInfoTest {
 		String managementPassword = "sample-mgmt-password";
 
 		SolaceMessagingInfo smi = new SolaceMessagingInfo(id, clientUsername, clientPassword, msgVpnName, smfHost,
-				smfTlsHost, smfZipHost, webMessagingUri, webMessagingTlsUri, jmsJndiUri, jmsJndiTlsUri, restUris, restTlsUris, mqttUris, mqttTlsUris,
+				smfTlsHost, smfZipHost, webMessagingUris, webMessagingTlsUris, jmsJndiUri, jmsJndiTlsUri, restUris, restTlsUris, mqttUris, mqttTlsUris,
 				mqttWsUris, mqttWssUris, managementHostnames, managementPassword, managementUsername);
 
 		// Check Top Level stuff
@@ -72,8 +72,8 @@ public class SolaceMessagingServiceInfoTest {
 		assertEquals(smfTlsHost, smi.getSmfTlsHost());
 		assertEquals(smfZipHost, smi.getSmfZipHost());
 
-		// Check Web Messsaging
-		assertEquals(webMessagingUri, smi.getWebMessagingUri());
+		// Check Web Messaging
+		assertEquals(webMessagingUris, smi.getWebMessagingUris());
 
 		// Check JMS
 		assertEquals(jmsJndiUri, smi.getJmsJndiUri());

--- a/src/test/java/com/solace/labs/spring/cloud/core/SolaceMessagingServiceInfoTest.java
+++ b/src/test/java/com/solace/labs/spring/cloud/core/SolaceMessagingServiceInfoTest.java
@@ -40,13 +40,13 @@ public class SolaceMessagingServiceInfoTest {
 		String clientUsername = "sample-client-username";
 		String clientPassword = "sample-client-password";
 		String msgVpnName = "sample-msg-vpn";
-		String smfHost = "tcp://192.168.1.50:7000";
-		String smfTlsHost = "tcps://192.168.1.50:7003";
-		String smfZipHost = "tcp://192.168.1.50:7001";
+		List<String> smfHosts = Arrays.asList("tcp://192.168.1.50:7000");
+		List<String> smfTlsHosts = Arrays.asList("tcps://192.168.1.50:7003");
+		List<String> smfZipHosts = Arrays.asList("tcp://192.168.1.50:7001");
 		List<String> webMessagingUris = Arrays.asList("http://192.168.1.50:80");
 		List<String> webMessagingTlsUris = Arrays.asList("https://192.168.1.50:80");
-		String jmsJndiUri = "smf://192.168.1.50:7000";
-		String jmsJndiTlsUri = "smfs://192.168.1.50:7003";
+		List<String> jmsJndiUris = Arrays.asList("smf://192.168.1.50:7000");
+		List<String> jmsJndiTlsUris = Arrays.asList("smfs://192.168.1.50:7003");
 		List<String> mqttUris = Arrays.asList("tcp://192.168.1.50:7020");
 		List<String> mqttTlsUris = Arrays.asList("ssl://192.168.1.50:7021");
 		List<String> mqttWsUris = Arrays.asList("ws://192.168.1.50:7022");
@@ -57,8 +57,8 @@ public class SolaceMessagingServiceInfoTest {
 		String managementUsername = "sample-mgmt-username";
 		String managementPassword = "sample-mgmt-password";
 
-		SolaceMessagingInfo smi = new SolaceMessagingInfo(id, clientUsername, clientPassword, msgVpnName, smfHost,
-				smfTlsHost, smfZipHost, webMessagingUris, webMessagingTlsUris, jmsJndiUri, jmsJndiTlsUri, restUris, restTlsUris, mqttUris, mqttTlsUris,
+		SolaceMessagingInfo smi = new SolaceMessagingInfo(id, clientUsername, clientPassword, msgVpnName, smfHosts,
+				smfTlsHosts, smfZipHosts, webMessagingUris, webMessagingTlsUris, jmsJndiUris, jmsJndiTlsUris, restUris, restTlsUris, mqttUris, mqttTlsUris,
 				mqttWsUris, mqttWssUris, managementHostnames, managementPassword, managementUsername);
 
 		// Check Top Level stuff
@@ -68,16 +68,16 @@ public class SolaceMessagingServiceInfoTest {
 		assertEquals(msgVpnName, smi.getMsgVpnName());
 
 		// Check SMF
-		assertEquals(smfHost, smi.getSmfHost());
-		assertEquals(smfTlsHost, smi.getSmfTlsHost());
-		assertEquals(smfZipHost, smi.getSmfZipHost());
+		assertEquals(smfHosts, smi.getSmfHosts());
+		assertEquals(smfTlsHosts, smi.getSmfTlsHosts());
+		assertEquals(smfZipHosts, smi.getSmfZipHosts());
 
 		// Check Web Messaging
 		assertEquals(webMessagingUris, smi.getWebMessagingUris());
 
 		// Check JMS
-		assertEquals(jmsJndiUri, smi.getJmsJndiUri());
-		assertEquals(jmsJndiTlsUri, smi.getJmsJndiTlsUri());
+		assertEquals(jmsJndiUris, smi.getJmsJndiUris());
+		assertEquals(jmsJndiTlsUris, smi.getJmsJndiTlsUris());
 
 		// Check MQTT
 		assertThat(smi.getMqttUris(), is(mqttUris));

--- a/src/test/java/com/solace/labs/spring/cloud/core/SolaceMessagingServiceInfoTest.java
+++ b/src/test/java/com/solace/labs/spring/cloud/core/SolaceMessagingServiceInfoTest.java
@@ -41,16 +41,14 @@ public class SolaceMessagingServiceInfoTest {
 		String clientPassword = "sample-client-password";
 		String msgVpnName = "sample-msg-vpn";
 		List<String> smfHosts = Arrays.asList("tcp://192.168.1.50:7000");
-		List<String> smfTlsHosts = Arrays.asList("tcps://192.168.1.50:7003");
+		List<String> smfTlsHosts = Arrays.asList("tcps://192.168.1.50:7003", "tcps://192.168.1.51:7003");
 		List<String> smfZipHosts = Arrays.asList("tcp://192.168.1.50:7001");
-		List<String> webMessagingUris = Arrays.asList("http://192.168.1.50:80");
-		List<String> webMessagingTlsUris = Arrays.asList("https://192.168.1.50:80");
 		List<String> jmsJndiUris = Arrays.asList("smf://192.168.1.50:7000");
-		List<String> jmsJndiTlsUris = Arrays.asList("smfs://192.168.1.50:7003");
+		List<String> jmsJndiTlsUris = Arrays.asList("smfs://192.168.1.50:7003", "smfs://192.168.1.51:7003");
 		List<String> mqttUris = Arrays.asList("tcp://192.168.1.50:7020");
-		List<String> mqttTlsUris = Arrays.asList("ssl://192.168.1.50:7021");
+		List<String> mqttTlsUris = Arrays.asList("ssl://192.168.1.50:7021", "ssl://192.168.1.51:7021");
 		List<String> mqttWsUris = Arrays.asList("ws://192.168.1.50:7022");
-		List<String> mqttWssUris = Arrays.asList("wss://192.168.1.50:7023");
+		List<String> mqttWssUris = Arrays.asList("wss://192.168.1.50:7023", "wss://192.168.1.51:7023");
 		List<String> restUris = Arrays.asList("http://192.168.1.50:7018");
 		List<String> restTlsUris = Arrays.asList("https://192.168.1.50:7019");
 		List<String> managementHostnames = Arrays.asList("vmr-Medium-VMR-0");
@@ -58,7 +56,7 @@ public class SolaceMessagingServiceInfoTest {
 		String managementPassword = "sample-mgmt-password";
 
 		SolaceMessagingInfo smi = new SolaceMessagingInfo(id, clientUsername, clientPassword, msgVpnName, smfHosts,
-				smfTlsHosts, smfZipHosts, webMessagingUris, webMessagingTlsUris, jmsJndiUris, jmsJndiTlsUris, restUris, restTlsUris, mqttUris, mqttTlsUris,
+				smfTlsHosts, smfZipHosts, jmsJndiUris, jmsJndiTlsUris, restUris, restTlsUris, mqttUris, mqttTlsUris,
 				mqttWsUris, mqttWssUris, managementHostnames, managementPassword, managementUsername);
 
 		// Check Top Level stuff
@@ -68,22 +66,19 @@ public class SolaceMessagingServiceInfoTest {
 		assertEquals(msgVpnName, smi.getMsgVpnName());
 
 		// Check SMF
-		assertEquals(smfHosts, smi.getSmfHosts());
-		assertEquals(smfTlsHosts, smi.getSmfTlsHosts());
-		assertEquals(smfZipHosts, smi.getSmfZipHosts());
-
-		// Check Web Messaging
-		assertEquals(webMessagingUris, smi.getWebMessagingUris());
+		assertEquals("tcp://192.168.1.50:7000", smi.getSmfHost());
+		assertEquals("tcps://192.168.1.50:7003,tcps://192.168.1.51:7003", smi.getSmfTlsHost());
+		assertEquals("tcp://192.168.1.50:7001", smi.getSmfZipHost());
 
 		// Check JMS
-		assertEquals(jmsJndiUris, smi.getJmsJndiUris());
-		assertEquals(jmsJndiTlsUris, smi.getJmsJndiTlsUris());
+		assertEquals("smf://192.168.1.50:7000", smi.getJmsJndiUri());
+		assertEquals("smfs://192.168.1.50:7003,smfs://192.168.1.51:7003", smi.getJmsJndiTlsUri());
 
 		// Check MQTT
-		assertThat(smi.getMqttUris(), is(mqttUris));
-		assertThat(smi.getMqttTlsUris(), is(mqttTlsUris));
-		assertThat(smi.getMqttWsUris(), is(mqttWsUris));
-		assertThat(smi.getMqttWssUris(), is(mqttWssUris));
+		assertThat(smi.getMqttUris(), is(Arrays.asList("tcp://192.168.1.50:7020")));
+		assertThat(smi.getMqttTlsUris(), is(Arrays.asList("ssl://192.168.1.50:7021", "ssl://192.168.1.51:7021")));
+		assertThat(smi.getMqttWsUris(), is(Arrays.asList("ws://192.168.1.50:7022")));
+		assertThat(smi.getMqttWssUris(), is(Arrays.asList("wss://192.168.1.50:7023", "wss://192.168.1.51:7023")));
 
 		// Check REST
 		assertThat(smi.getRestUris(), is(restUris));

--- a/src/test/java/com/solace/labs/spring/cloud/core/SolaceMessagingServiceInfoTest.java
+++ b/src/test/java/com/solace/labs/spring/cloud/core/SolaceMessagingServiceInfoTest.java
@@ -40,11 +40,11 @@ public class SolaceMessagingServiceInfoTest {
 		String clientUsername = "sample-client-username";
 		String clientPassword = "sample-client-password";
 		String msgVpnName = "sample-msg-vpn";
-		List<String> smfHosts = Arrays.asList("tcp://192.168.1.50:7000");
-		List<String> smfTlsHosts = Arrays.asList("tcps://192.168.1.50:7003", "tcps://192.168.1.51:7003");
-		List<String> smfZipHosts = Arrays.asList("tcp://192.168.1.50:7001");
-		List<String> jmsJndiUris = Arrays.asList("smf://192.168.1.50:7000");
-		List<String> jmsJndiTlsUris = Arrays.asList("smfs://192.168.1.50:7003", "smfs://192.168.1.51:7003");
+		String smfHost = "tcp://192.168.1.50:7000";
+		String smfTlsHost = "tcps://192.168.1.50:7003";
+		String smfZipHost = "tcp://192.168.1.50:7001";
+		String jmsJndiUri = "smf://192.168.1.50:7000";
+		String jmsJndiTlsUri = "smfs://192.168.1.50:7003";
 		List<String> mqttUris = Arrays.asList("tcp://192.168.1.50:7020");
 		List<String> mqttTlsUris = Arrays.asList("ssl://192.168.1.50:7021", "ssl://192.168.1.51:7021");
 		List<String> mqttWsUris = Arrays.asList("ws://192.168.1.50:7022");
@@ -55,8 +55,8 @@ public class SolaceMessagingServiceInfoTest {
 		String managementUsername = "sample-mgmt-username";
 		String managementPassword = "sample-mgmt-password";
 
-		SolaceMessagingInfo smi = new SolaceMessagingInfo(id, clientUsername, clientPassword, msgVpnName, smfHosts,
-				smfTlsHosts, smfZipHosts, jmsJndiUris, jmsJndiTlsUris, restUris, restTlsUris, mqttUris, mqttTlsUris,
+		SolaceMessagingInfo smi = new SolaceMessagingInfo(id, clientUsername, clientPassword, msgVpnName, smfHost,
+				smfTlsHost, smfZipHost, jmsJndiUri, jmsJndiTlsUri, restUris, restTlsUris, mqttUris, mqttTlsUris,
 				mqttWsUris, mqttWssUris, managementHostnames, managementPassword, managementUsername);
 
 		// Check Top Level stuff
@@ -67,12 +67,12 @@ public class SolaceMessagingServiceInfoTest {
 
 		// Check SMF
 		assertEquals("tcp://192.168.1.50:7000", smi.getSmfHost());
-		assertEquals("tcps://192.168.1.50:7003,tcps://192.168.1.51:7003", smi.getSmfTlsHost());
+		assertEquals("tcps://192.168.1.50:7003", smi.getSmfTlsHost());
 		assertEquals("tcp://192.168.1.50:7001", smi.getSmfZipHost());
 
 		// Check JMS
 		assertEquals("smf://192.168.1.50:7000", smi.getJmsJndiUri());
-		assertEquals("smfs://192.168.1.50:7003,smfs://192.168.1.51:7003", smi.getJmsJndiTlsUri());
+		assertEquals("smfs://192.168.1.50:7003", smi.getJmsJndiTlsUri());
 
 		// Check MQTT
 		assertThat(smi.getMqttUris(), is(Arrays.asList("tcp://192.168.1.50:7020")));


### PR DESCRIPTION
 Removed the webMessaging properties, as they are only used by JavaScript applications. The VCAP_SERVICES properties smfHosts, smfTlsHosts, smfZipHosts, jmsJndiUris and jmsJndiTlsUris are now JSON arrays, but are presented as single comma-separated strings in the SolaceMessagingInfo class.